### PR TITLE
Added failing test case: custom render codeBlock()

### DIFF
--- a/tests/006-render-custom-codeblock.phpt
+++ b/tests/006-render-custom-codeblock.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Check for custom render of codeBlocks
+--SKIPIF--
+<?php if (!extension_loaded("sundown")) print "skip"; ?>
+--FILE--
+<?php
+
+class CustomRender extends Sundown\Render\Base
+{
+    public function blockCode($code, $language)
+    {
+        echo "OK.";
+        return $code;
+    }
+}
+
+$m = new Sundown\Markdown(
+    new CustomRender(),
+    array()
+);
+
+$m->render('
+This is a normal paragraph.
+
+    This is a code block
+
+This is another normal paragraph.
+');
+
+$m2 = new Sundown\Markdown(
+    new CustomRender(),
+    array('fenced_code_blocks' => true)
+);
+
+$m->render('
+This is a normal paragraph.
+
+``` php
+This is a fenced code block
+```
+
+This is another normal paragraph.
+');
+
+--EXPECT--
+OK.OK.


### PR DESCRIPTION
It seems an overriden codeBlock($code, $language) method in a custom
renderer never gets called. This test checks for normal code blocks and
fenced code blocks.

Unless I'm setting up the renderer wrong?
