### PR TITLE
Make travis report test failure since make test didn't report exit code

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-
 desc "compile php-sundown"
 task :compile => ['sundown/src/markdown.h'] do
 	sh "phpize"
@@ -19,6 +18,7 @@ desc "run php test cases"
 task :test do
 	ENV["TESTS"] = "--show-diff -q"
 	sh "make test"
+	sh "cat tests/*.diff; if [ $? -eq 0 ];then exit 1; fi"
 end
 
 desc "Run conformance tests"


### PR DESCRIPTION
Hi, chobie,

  make test didn't report exit code properly, even make test failed, travis will not complain.

please refer: 
https://github.com/reeze/php-leveldb/blob/master/travis/run-test.sh
https://bugs.php.net/bug.php?id=60285

Look at this one, test failed but reported sucess
http://travis-ci.org/#!/reeze/php-sundown/jobs/1670528

if test failed, cat will output the diffs,  it will help us debugging :)

Thanks
