### PR TITLE
Fix build in php-src

### DIFF
--- a/php_sundown.h
+++ b/php_sundown.h
@@ -24,7 +24,7 @@
  * Zend will use when loading this module
  */
 extern zend_module_entry sundown_module_entry;
-#define phpext_sundown_ptr &sundown_module_entry;
+#define phpext_sundown_ptr &sundown_module_entry
 
 extern zend_class_entry *sundown_class_entry, *php_sundown_buffer_class_entry;
 


### PR DESCRIPTION
There should no ';' after the macro, this will break build in php-src

main/internal_functions_cli.c:80:2: error: expected '}'
        phpext_sundown_ptr,
        ^
/Users/reeze/Opensource/php-test/php-src-5.3-dev/ext/sundown/php_sundown.h:27:49: note: expanded from macro 'phpext_sundown_ptr'
# define phpext_sundown_ptr &sundown_module_entry;

```
                                            ^
```

main/internal_functions_cli.c:58:54: note: to match this '{'
static zend_module_entry *php_builtin_extensions[] = {
