### PR TITLE
fix segfault in sundown_render_base

### DIFF
--- a/php_sundown.h
+++ b/php_sundown.h
@@ -163,7 +163,7 @@ static int call_user_function_v(HashTable *function_table, zval **object_pp, zva
 	TSRMLS_FETCH();
 
 	if (param_count > 0) {
-		params = emalloc(sizeof(zval**) * param_count);
+		params = emalloc(sizeof(zval*) * param_count);
 		va_start(ap, param_count);
 		for (i=0; i<param_count;i++) {
 			params[i] = va_arg(ap, zval*);

--- a/render_base.c
+++ b/render_base.c
@@ -227,7 +227,8 @@ PHP_METHOD(sundown_render_base, blockHtml)
 PHP_METHOD(sundown_render_base, header)
 {
 	char *htext;
-	int htext_len, header_level;
+	int htext_len;
+	long header_level;
 	
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC,
 		"sl", &htext, &htext_len, &header_level) == FAILURE) {


### PR DESCRIPTION
Running tests/999-regression-no28.phpt

```
Program received signal SIGSEGV, Segmentation fault.
__memcpy_ssse3_back () at ../sysdeps/x86_64/multiarch/memcpy-ssse3-back.S:2757
2757        mov 1(%rsi), %dx
(gdb) bt
#0  __memcpy_ssse3_back () at ../sysdeps/x86_64/multiarch/memcpy-ssse3-back.S:2757
#1  0x000055555575d218 in memcpy (__len=3, __src=0x7fff00000000, __dest=0x7ffff7fbbfb8) at /usr/include/bits/string3.h:51
#2  _estrndup (s=0x7fff00000000 <Address 0x7fff00000000 out of bounds>, length=3) at /usr/src/debug/php-5.5.7/Zend/zend_alloc.c:2655
#3  0x00007fffed5433f8 in zim_sundown_render_base_header (ht=<optimized out>, return_value=0x7ffff7fbc118, return_value_ptr=<optimized out>, this_ptr=<optimized out>, 
    return_value_used=<optimized out>) at /home/rpmbuild/SPECS/remirepo/php/pecl/php-pecl-sundown/sundown-0.3.10/render_base.c:236
#4  0x0000555555771f7b in dtrace_execute_internal (execute_data_ptr=<optimized out>, fci=<optimized out>, return_value_used=<optimized out>)
    at /usr/src/debug/php-5.5.7/Zend/zend_dtrace.c:97
#5  0x00005555557742fb in zend_call_function (fci=fci@entry=0x7fffffff9f90, fci_cache=0x7fffffff9ea0, fci_cache@entry=0x0) at /usr/src/debug/php-5.5.7/Zend/zend_execute_API.c:959
#6  0x000055555577439e in call_user_function_ex (function_table=function_table@entry=0x0, object_pp=<optimized out>, function_name=<optimized out>, 
    retval_ptr_ptr=retval_ptr_ptr@entry=0x7fffffffa028, param_count=<optimized out>, params=params@entry=0x7ffff7fc0c28, no_separation=no_separation@entry=1, 
    symbol_table=symbol_table@entry=0x0) at /usr/src/debug/php-5.5.7/Zend/zend_execute_API.c:727
#7  0x00005555557743f2 in call_user_function (function_table=function_table@entry=0x0, object_pp=<optimized out>, function_name=<optimized out>, retval_ptr=0x7ffff7fbca88, 
    param_count=<optimized out>, params=params@entry=0x7ffff7fbcab8) at /usr/src/debug/php-5.5.7/Zend/zend_execute_API.c:700
#8  0x00007fffed5401ad in call_user_function_v (function_table=0x0, object_pp=object_pp@entry=0x7fffffffa3e8, function_name=function_name@entry=0x7fffffffa110, 
    retval_ptr=0x7ffff7fbca88, param_count=param_count@entry=2, function_table=0x0) at /home/rpmbuild/SPECS/remirepo/php/pecl/php-pecl-sundown/sundown-0.3.10/php_sundown.h:176
#9  0x00007fffed5419eb in rndr_header (ob=0x555555cba090, text=<optimized out>, level=1, opaque=0x7fffffffa3d0)
    at /home/rpmbuild/SPECS/remirepo/php/pecl/php-pecl-sundown/sundown-0.3.10/sundown_markdown.c:43
#10 0x00007fffed54a4e7 in parse_atxheader (size=<optimized out>, data=<optimized out>, rndr=<optimized out>, ob=<optimized out>)
    at /home/rpmbuild/SPECS/remirepo/php/pecl/php-pecl-sundown/sundown-0.3.10/sundown/src/markdown.c:1814
#11 parse_block (ob=ob@entry=0x555555cba090, rndr=rndr@entry=0x555555cbab20, 
    data=0x555555cba1b0 "# Doc\n\n![](doesnt/exists.jpg)\n\n![](https://www.google.com/images/srpr/logo3w.png)\n", size=82)
    at /home/rpmbuild/SPECS/remirepo/php/pecl/php-pecl-sundown/sundown-0.3.10/sundown/src/markdown.c:2203
#12 0x00007fffed54c6ba in parse_block (size=<optimized out>, data=<optimized out>, rndr=0x555555cbab20, ob=0x555555cba090) at /usr/include/bits/string3.h:84
#13 sd_markdown_render (ob=ob@entry=0x555555cba090, document=0x7ffff7fbc070 "# Doc\n\n![](doesnt/exists.jpg)\n\n![](https://www.google.com/images/srpr/logo3w.png)", 
    doc_size=<optimized out>, md=md@entry=0x555555cbab20) at /home/rpmbuild/SPECS/remirepo/php/pecl/php-pecl-sundown/sundown-0.3.10/sundown/src/markdown.c:2517
#14 0x00007fffed542af0 in php_sundown_markdon_render (render_type=<optimized out>, ht=<optimized out>, return_value=0x7ffff7fbc848, return_value_ptr=<optimized out>, 
    this_ptr=<optimized out>, return_value_used=<optimized out>) at /home/rpmbuild/SPECS/remirepo/php/pecl/php-pecl-sundown/sundown-0.3.10/sundown_markdown.c:444
#15 0x0000555555771f7b in dtrace_execute_internal (execute_data_ptr=<optimized out>, fci=<optimized out>, return_value_used=<optimized out>)
    at /usr/src/debug/php-5.5.7/Zend/zend_dtrace.c:97
#16 0x0000555555831de5 in zend_do_fcall_common_helper_SPEC (execute_data=<optimized out>) at /usr/src/debug/php-5.5.7/Zend/zend_vm_execute.h:552
#17 0x00005555557abda8 in execute_ex (execute_data=0x7ffff7f86280) at /usr/src/debug/php-5.5.7/Zend/zend_vm_execute.h:363
#18 0x0000555555771e79 in dtrace_execute_ex (execute_data=<optimized out>) at /usr/src/debug/php-5.5.7/Zend/zend_dtrace.c:73
#19 0x0000555555783950 in zend_execute_scripts (type=type@entry=8, retval=retval@entry=0x0, file_count=file_count@entry=3) at /usr/src/debug/php-5.5.7/Zend/zend.c:1320
#20 0x00005555557237a5 in php_execute_script (primary_file=primary_file@entry=0x7fffffffcaa0) at /usr/src/debug/php-5.5.7/main/main.c:2489
#21 0x0000555555833df8 in do_cli (argc=5, argv=0x555555b83480) at /usr/src/debug/php-5.5.7/sapi/cli/php_cli.c:994
#22 0x000055555560e310 in main (argc=5, argv=0x555555b83480) at /usr/src/debug/php-5.5.7/sapi/cli/php_cli.c:1378
```
